### PR TITLE
FIX: Syntax error in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
   packages=find_packages(),
   install_requires=[
         'obspy>=1.0.2',
-        'pyqtgraph=0.10.0',
+        'pyqtgraph==0.10.0',
         'scandir>=1.4',
         'pyproj>=1.9.5.1',
         'scipy',


### PR DESCRIPTION
I didn't found the doc about it but I *think* that `=` is not a legal syntax, `==` is the right one here.